### PR TITLE
External encoding is now set to UTF-8 to support unicode characters

### DIFF
--- a/bin/omglog
+++ b/bin/omglog
@@ -2,7 +2,7 @@
 # coding: utf-8
 require 'rb-fsevent'
 
-Encoding.default_external = Encoding::UTF_8
+Encoding.default_external = Encoding::UTF_8 if RUBY_VERSION > '1.8.7'
 
 CLEAR = "\n----\n"
 YELLOW, BLUE, GREY, HIGHLIGHT = '0;33', '0;34', '0;90', '1;30;47'


### PR DESCRIPTION
If there are special characters in the commit message, running `omglog` on the repository will fail with

<pre>
/Users/darthdeus/.rvm/gems/ruby-1.9.2-p290@global/gems/omglog-0.0.2/bin/omglog:16:in `split': invalid byte sequence in US-ASCII (ArgumentError)
    from /Users/darthdeus/.rvm/gems/ruby-1.9.2-p290@global/gems/omglog-0.0.2/bin/omglog:16:in `block in omglog'
    from /Users/darthdeus/.rvm/gems/ruby-1.9.2-p290@global/gems/omglog-0.0.2/bin/omglog:15:in `tap'
    from /Users/darthdeus/.rvm/gems/ruby-1.9.2-p290@global/gems/omglog-0.0.2/bin/omglog:15:in `omglog'
    from /Users/darthdeus/.rvm/gems/ruby-1.9.2-p290@global/gems/omglog-0.0.2/bin/omglog:52:in `<top (required)>'
    from /Users/darthdeus/.rvm/gems/ruby-1.9.2-p290/bin/omglog:19:in `load'
    from /Users/darthdeus/.rvm/gems/ruby-1.9.2-p290/bin/omglog:19:in `<main>'
</pre>


This can be easily fixed with `Encoding.default_external = Encoding::UTF_8`

Steps to reproduce

<pre>
mkdir sandbox
cd sandbox
git init
echo foo > bar
git add .
git commit -m "initial čommit"
omglog  # exception raised here because of the č character
</pre>
