### PR TITLE
Using a newer version of rb-fsevent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     ffi (1.0.11)
-    rb-fsevent (0.4.3.1)
+    rb-fsevent (0.9.1)
     rb-inotify (0.8.8)
       ffi (>= 0.5.0)
 

--- a/omglog.gemspec
+++ b/omglog.gemspec
@@ -9,6 +9,6 @@ Gem::Specification.new do |s|
   s.executables = ['omglog']
   s.homepage    = 'http://github.com/benhoskings/omglog'
 
-  s.add_dependency 'rb-fsevent', '~> 0.4.3'
+  s.add_dependency 'rb-fsevent', '~> 0.9.0'
   s.add_dependency 'rb-inotify', '~> 0.8.8'
 end


### PR DESCRIPTION
Hello,

The gem is currently using rb-fsevent 0.4.3, which by default has difficulty installing on many OS X installs: https://github.com/thibaudgg/rb-fsevent/issues/31.

This pull request uses the newer 0.9.0 version, which fixes this problem.

Thanks!
