### PR TITLE
OmgLog is kinda broken on small repositories 

### DIFF
--- a/lib/omglog.rb
+++ b/lib/omglog.rb
@@ -19,7 +19,10 @@ module Omglog
     def self.run
       rows, cols = `tput lines; tput cols`.scan(/\d+/).map(&:to_i)
       `#{LOG_CMD} -#{rows}`.tap {|log|
-        print CLEAR + log.split("\n")[0...(rows - 1)].map {|l|
+        log_lines = Array.new(rows, '')
+        log_lines.unshift *log.split("\n")
+
+        print CLEAR + log_lines[0...(rows - 1)].map {|l|
           commit = l.scan(LOG_REGEX).flatten.map(&:to_s)
           commit.any? ? render_commit(commit, cols) : l
         }.join("\n") + "\n" + "\e[#{GREY}mupdated #{Time.now.strftime("%a %H:%M:%S")}\e[m ".rjust(cols + 8)


### PR DESCRIPTION
When the terminal window has more `rows` than the git log has lines, omglog does not fill the entire window, making “refresh” prints render under each other.

An alternative implementation would be:

``` rb
log_lines = log.split("\n")[0...(rows - 1)]
until log_lines.size >= rows - 1
  log_lines << ''
end

print CLEAR + log_lines.map {|l|
```

which will not generate `rows` extra objects on each request.
