### PR TITLE
Allow omglog to accept command line arguments to passed on to git log

### DIFF
--- a/lib/omglog.rb
+++ b/lib/omglog.rb
@@ -13,7 +13,7 @@ module Omglog
     CLEAR = "\n----\n"
     YELLOW, BLUE, GREY, HIGHLIGHT = '0;33', '0;34', '0;90', '1;30;47'
     SHORTEST_MESSAGE = 12
-    LOG_CMD = %{git log --all --date-order --graph --color --pretty="format: \2%h\3\2%d\3\2 %an, %ar\3\2 %s\3"}
+    LOG_CMD = %{git log --all --date-order --graph --color --pretty="format: \2%h\3\2%d\3\2 %an, %ar\3\2 %s\3"} + " " + ARGV.join(" ")
     LOG_REGEX = /(.*)\u0002(.*)\u0003\u0002(.*)\u0003\u0002(.*)\u0003\u0002(.*)\u0003/
 
     def self.run


### PR DESCRIPTION
This allows for omitting certain branches/globs from the output.

For example:
omglog --not --glob="refs/notes"
