### PR TITLE
set Gemfile source to https://rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'rb-fsevent'
 gem 'rb-inotify'


### PR DESCRIPTION
Changed the source in Gemfile to https://rubygems.org, because 'source :rubygems' is deprecated 