### PR TITLE
Adds a basic readme with setup instructions for RVM users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,11 @@ If you are using RVM and using unsupported flavors of ruby, the following will a
 
 _This example is using ruby-2.2.0 and the @global gemset._
 
-**Install to global gemset**
+**Install to global gemset and generate wrapper**
 
     $ rvm install ruby-2.2.0
     $ rvm use ruby-2.2.0
     $ rvm @global do gem install omglog
-    $ rvm wrapper ruby-2.2.0@global launch omglog
+    $ rvm wrapper ruby-2.2.0@global --no-prefix omglog
 
-After creating the wrapper, to launch `omglog` via the wrapper run:
-
-    $ launch_omglog
-
-_OR, create an alias for convenience..._
-
-Edit your `.zshrc` or `.bashrc` and add:
-
-    alias omglog='launch_omglog'
+_Make sure you don't have the `omglog` gem installed in any other gemsets, otherwise they may take precendence over this wrapper._

--- a/README.md
+++ b/README.md
@@ -3,14 +3,21 @@
 Start `omglog` in a git repository. It will watch the `.git` directory for changes are re-render the repository graph.
 
 
-##Requirement
+##Requirements
 
-Ruby version that supports file system watcher. _JRuby is currently not supported._
+Ruby version that supports fsevents on OS X, or inotify on linux. _JRuby is not currently supported._
 
 
 ##Install
 
     $ gem install omglog
+
+
+##Usage
+
+In terminal, run from the root a git repository:
+
+    $ omglog
 
 
 ## Use with RVM
@@ -34,4 +41,4 @@ _OR, create an alias for convenience..._
 
 Edit your `.zshrc` or `.bashrc` and add:
 
-    alias omgl='launch_omglog'
+    alias omglog='launch_omglog'

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+##Description
+
+Start `omglog` in a git repository. It will watch the `.git` directory for changes are re-render the repository graph.
+
+
+##Requirement
+
+Ruby version that supports file system watcher. _JRuby is currently not supported._
+
+
+##Install
+
+    $ gem install omglog
+
+
+## Use with RVM
+
+If you are using RVM and using unsupported flavors of ruby, the following will allow you to configure a wrapper for `omglog` that will always launch it using a suppored version of ruby and the gemset of your choosing.
+
+_This example is using ruby-2.2.0 and the @global gemset._
+
+**Install to global gemset**
+
+    $ rvm install ruby-2.2.0
+    $ rvm use ruby-2.2.0
+    $ rvm @global do gem install omglog
+    $ rvm wrapper ruby-2.2.0@global launch omglog
+
+After creating the wrapper, to launch `omglog` via the wrapper run:
+
+    $ launch_omglog
+
+_OR, create an alias for convenience..._
+
+Edit your `.zshrc` or `.bashrc` and add:
+
+    alias omgl='launch_omglog'


### PR DESCRIPTION
Using the omglog gem with RVM when JRuby is the active ruby is inconvenient. This readme adds a brief introduction to the gem and offers a method of configuration that will allow RVM users a way to always execute the gem using a chosen ruby version and gemset.